### PR TITLE
Add IS_PGCAT env flag to disable SSL for PgCat

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -19,7 +19,7 @@ const interceptors = [
 
 const db = createPool(process.env.DB_URL!, {
     interceptors,
-    ssl: {
+    ssl: process.env.IS_PGCAT === 'true' ? undefined : {
         rejectUnauthorized: false
     }
 })


### PR DESCRIPTION
## Summary
- When IS_PGCAT=true, skip SSL config for slonik connection to support PgCat pooler
- No behavioral change when env var is not set